### PR TITLE
Fix `mpris_client` package name

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (executable
   (name spotify_cli)
-  (libraries obus mpris mpris_clients spotify-web-api cmdliner)
+  (libraries obus mpris mpris-clients spotify-web-api cmdliner)
   (modules spotify_cli backend spotify_cli_types commands)
   (preprocess (pps lwt_ppx)))
 


### PR DESCRIPTION
Mpris client package is missnamed `mpris_clients` and causes an error at compile time. Fixed to `mpris-clients` according new package name (https://github.com/johnelse/ocaml-mpris/commit/ca784b79c60d150dccd781053c677a72b7ef267b).
